### PR TITLE
Remove unused nginx dockerfile

### DIFF
--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,2 +1,0 @@
-FROM nginx:latest
-COPY ./build/nginx/default.conf /etc/nginx/conf.d/


### PR DESCRIPTION
This file is unused. All docker image files should be in docker directory.